### PR TITLE
2.1.0

### DIFF
--- a/example.py
+++ b/example.py
@@ -4,7 +4,7 @@ import asyncio
 from aiohttp import ClientSession
 
 from pypollencom import Client
-from pypollencom.errors import RequestError
+from pypollencom.errors import PollenComError
 
 
 async def allergens(client: Client) -> None:
@@ -42,14 +42,16 @@ async def run(websession):
     try:
         # Create a client:
         client = Client('80238', websession)
+        print('Client instantiated for ZIP "{0}"'.format(client.zip_code))
 
         # Work with allergen data:
+        print()
         await allergens(client)
 
         # Work with disease data:
         print()
         await disease(client)
-    except RequestError as err:
+    except PollenComError as err:
         print(err)
 
 

--- a/pypollencom/__version__.py
+++ b/pypollencom/__version__.py
@@ -1,2 +1,2 @@
 """Define a version constant."""
-__version__ = '2.0.1'
+__version__ = '2.1.0'

--- a/pypollencom/allergens.py
+++ b/pypollencom/allergens.py
@@ -1,4 +1,6 @@
 """Define an object to work with "Allergens" endpoints."""
+from .decorators import raise_on_invalid_zip
+from .errors import InvalidZipError, RequestError
 
 
 class Allergens(object):
@@ -8,18 +10,27 @@ class Allergens(object):
         """Initialize."""
         self._request = request
 
+    @raise_on_invalid_zip
     async def current(self):
         """Get current allergy conditions."""
         return await self._request('get', 'forecast/current/pollen')
 
+    @raise_on_invalid_zip
     async def extended(self):
         """Get extended allergen info."""
         return await self._request('get', 'forecast/extended/pollen')
 
+    @raise_on_invalid_zip
     async def historic(self):
         """Get historic allergen info."""
         return await self._request('get', 'forecast/historic/pollen')
 
     async def outlook(self):
         """Get allergen outlook."""
-        return await self._request('get', 'forecast/outlook')
+        try:
+            return await self._request('get', 'forecast/outlook')
+        except RequestError as err:
+            if '404' in str(err):
+                raise InvalidZipError('No data returned for ZIP code')
+            else:
+                raise RequestError(err)

--- a/pypollencom/decorators.py
+++ b/pypollencom/decorators.py
@@ -1,0 +1,15 @@
+"""Define useful decorators."""
+from .errors import InvalidZipError
+
+
+def raise_on_invalid_zip(func):
+    """Raise an exception when there's no data (via a bad ZIP code)."""
+
+    async def decorator(*args, **kwargs):
+        """Decorate."""
+        data = await func(*args, **kwargs)
+        if not data['Location']['periods']:
+            raise InvalidZipError('No data returned for ZIP code')
+        return data
+
+    return decorator

--- a/pypollencom/disease.py
+++ b/pypollencom/disease.py
@@ -1,4 +1,5 @@
 """Define an object to work with "Disease" endpoints."""
+from .decorators import raise_on_invalid_zip
 
 
 class Disease(object):  # pylint: disable=too-few-public-methods
@@ -8,6 +9,7 @@ class Disease(object):  # pylint: disable=too-few-public-methods
         """Initialize."""
         self._request = request
 
+    @raise_on_invalid_zip
     async def extended(self):
         """Get extended disease info."""
         return await self._request('get', 'forecast/extended/cold')

--- a/pypollencom/errors.py
+++ b/pypollencom/errors.py
@@ -5,5 +5,9 @@ class PollenComError(Exception):
     """Define a base package error."""
 
 
+class InvalidZipError(PollenComError):
+    """Define an error when a ZIP returns no valid data."""
+
+
 class RequestError(PollenComError):
     """Define a generic request error."""

--- a/tests/const.py
+++ b/tests/const.py
@@ -1,2 +1,3 @@
 """Define constants for tests."""
+TEST_BAD_ZIP = 'abcde'
 TEST_ZIP = '00123'

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -16,7 +16,7 @@ async def test_create():
     """Test the creation of a client."""
     async with aiohttp.ClientSession() as websession:
         client = Client(TEST_ZIP, websession)
-        assert client._zip_code == TEST_ZIP
+        assert client.zip_code == TEST_ZIP
 
 
 @pytest.mark.asyncio
@@ -25,8 +25,16 @@ async def test_request_error(aresponses, event_loop):
     aresponses.add(
         'www.pollen.com', '/api/bad_endpoint/{0}'.format(TEST_ZIP), 'get',
         aresponses.Response(text='', status=404))
+    aresponses.add(
+        'www.pollen.com', '/api/forecast/outlook/{0}'.format(TEST_ZIP),
+        'get', aresponses.Response(text='', status=500))
 
     with pytest.raises(RequestError):
         async with aiohttp.ClientSession(loop=event_loop) as websession:
             client = Client(TEST_ZIP, websession)
             await client.request('get', 'bad_endpoint')
+
+    with pytest.raises(RequestError):
+        async with aiohttp.ClientSession(loop=event_loop) as websession:
+            client = Client(TEST_ZIP, websession)
+            await client.allergens.outlook()


### PR DESCRIPTION
* Raise an `InvalidZipError` when no good data is returned.
* Raise an `InvalidZipError` when a call to `allergens.outlook()` returns a `404`.